### PR TITLE
fix: escape dollar sign in deals board template

### DIFF
--- a/src/app/features/deals/deals-board.component.ts
+++ b/src/app/features/deals/deals-board.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { AsyncPipe, CommonModule, NgFor } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { MatCardModule } from '@angular/material/card';
 
 @Component({
@@ -15,7 +15,7 @@ import { MatCardModule } from '@angular/material/card';
         <div class="space-y-2">
           <div *ngFor="let d of col.items" class="p-3 rounded-lg border border-gray-200 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-900">
             <div class="font-medium">{{d.name}}</div>
-            <div class="text-sm text-gray-500">${{d.amount}}</div>
+            <div class="text-sm text-gray-500">&#36;{{d.amount}}</div>
           </div>
         </div>
       </div>
@@ -30,3 +30,4 @@ export class DealsBoardComponent {
     { title: 'Negotiation', items: [{ name: 'Initech Audit', amount: 9000 }] },
   ];
 }
+


### PR DESCRIPTION
## Summary
- Escape dollar sign in deals board inline template with HTML entity to keep template a valid string

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `npm run build` *(fails: Could not resolve "@angular/animations/browser")*


------
https://chatgpt.com/codex/tasks/task_e_689bc7cc3b08832784e5d2c8cb2036fb