### PR TITLE
fix: add missing angular animations dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "high-ticket-sale-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^19.2.0",
         "@angular/cdk": "^19.2.19",
         "@angular/common": "^19.2.0",
         "@angular/compiler": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^19.2.0",
     "@angular/cdk": "^19.2.19",
     "@angular/common": "^19.2.0",
     "@angular/compiler": "^19.2.0",


### PR DESCRIPTION
## Summary
- add `@angular/animations` dependency to resolve runtime import error

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run build` *(fails: Could not resolve "@angular/animations/browser" due to missing package)*

------
https://chatgpt.com/codex/tasks/task_e_689bc9f160908327b032683d9c5c5809